### PR TITLE
Include components folder in purgecss rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ const purgeCSS = {
     content: [
       // add extra paths here for components/controllers which include tailwind classes
       './app/index.html',
-      './app/templates/**/*.hbs'
+      './app/templates/**/*.hbs',
+      './app/components/**/*.hbs'
     ],
     defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
   }
@@ -350,7 +351,8 @@ module.exports = function(defaults) {
               content: [
                 // add extra paths here for components/controllers which include tailwind classes
                 './app/index.html',
-                './app/templates/**/*.hbs'
+                './app/templates/**/*.hbs',
+                './app/components/**/*.hbs'
               ]
             }
           }
@@ -389,7 +391,8 @@ const purgeCSS = {
     content: [
       // add extra paths here for components/controllers which include tailwind classes
       './app/index.html',
-      './app/templates/**/*.hbs'
+      './app/templates/**/*.hbs',
+      './app/components/**/*.hbs'
     ],
     defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,8 @@ const purgeCSS = {
     content: [
       // add extra paths here for components/controllers which include tailwind classes
       './app/index.html',
-      './app/templates/**/*.hbs'
+      './app/templates/**/*.hbs',
+      './app/components/**/*.hbs'
     ],
     defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
   }


### PR DESCRIPTION
Ember 3.13 added a feature that allows placing component templates inside the `components` folder, alongside the component JavaScript files. This is now the officially suggested location to place components.

Ref: https://blog.emberjs.com/2019/09/25/ember-3-13-released.html
Ref: https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md

I ran into this when trying to deploy to Heroku, most of my CSS was missing - turned out to be because the component template files weren't included in the purgeCSS configuration