### PR TITLE
fix typo in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ In this example we are going to include the full configuration (whereas in reali
 
 ```bash
 mkdir app/tailwind
-npx tailwind init app/tailwind.config.js --full
+npx tailwind init app/tailwind/config.js --full
 ```
 
 Which should result in something like this


### PR DESCRIPTION
I think you meant that the tailwind config should be placed in the created directory?