### PR TITLE
Add dot as allowed character in default extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ const purgeCSS = {
       './app/templates/**/*.hbs',
       './app/components/**/*.hbs'
     ],
-    defaultExtractor: content => content.match(/[A-Za-z0-9-_:/]+/g) || []
+    defaultExtractor: content => content.match(/[A-Za-z0-9-_:/.]+/g) || []
   }
 }
 


### PR DESCRIPTION
This handles tailwind classes like "h-2.5" 

<img width="433" alt="Screenshot 2021-09-12 at 4 32 32 PM" src="https://user-images.githubusercontent.com/3893573/132993567-2479440e-5d3d-431f-99fe-dff0072b376b.png">

(ref: https://tailwindcss.com/docs/height#class-reference)